### PR TITLE
添加头文件依赖

### DIFF
--- a/cgi/hello_server.c
+++ b/cgi/hello_server.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <unistd.h>
 #include <stdlib.h>
 #include <netinet/in.h>
 #include <sys/socket.h>


### PR DESCRIPTION
hello_server.c 使用 read/open/close等函数，貌似没有引入头文件unistd.h，所以编译会报错：隐式申明函数，引入unistd.h 就好了。

另外，按照博文中的步骤，运行 hello_server.c 之后，通过curl请求，会报错：
>[1]    7960 segmentation fault  ./a.out

在Mac 和 Ubuntu16.04上都是如此，不知啥原因，因为我对C系统编程不太熟悉，不知能否指定下？谢谢